### PR TITLE
Build packages in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,30 @@
 version: 2
 jobs:
   build:
-    machine: true
-    working_directory: ~/dokku/plugn
-    parallelism: 1
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
-      - run: |
-          make circleci
-      - run: |
-          make deps
-          sudo add-apt-repository ppa:gophers/archive -y
-          sudo apt-get update
-          sudo apt-get -y install golang-1.11
-      - run: |
-          PATH="/usr/lib/go-1.11/bin:$PATH" GO111MODULE=on make build
+      - run:
+          command: |
+            make version
+            if [[ "$CIRCLE_BRANCH" == "release" ]]; then
+              export PACKAGECLOUD_REPOSITORY=josegonzalez/packages
+              make .env.docker
+            fi
+      - run: make circleci
+      - run: make build-docker-image
+      - run:
+          command: |
+            make build-in-docker
+            [[ -d build ]]  && sudo chown -R circleci:circleci build
+      - run: make validate-in-docker
       - store_artifacts:
           path: build
           destination: build
-      - run: |
-          PATH="/usr/lib/go-1.11/bin:$PATH" tests/**/tests.sh
-      - deploy:
-          name: release
+      - run:
           command: |
-            if [ "${CIRCLE_BRANCH}" == "release" ]; then
-              PATH="/usr/lib/go-1.11/bin:$PATH" make release
+            if [[ "$CIRCLE_BRANCH" == "release" ]]; then
+              make release-in-docker
             fi
+            make release-packagecloud-in-docker

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile*
+LICENSE
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,27 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Build output
+build/*
+
+# Release output
+release/*
+
+# Validation output
+validation/*
+
+# .env files
+.env*
+
 example/plugins/enabled/*
 example/plugins/available/remote/remote
-release
-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,0 @@
-FROM ubuntu-debootstrap
-ADD ./plugn /bin/plugn

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,2 +1,12 @@
-FROM golang:1.12.0
+FROM golang:1.12.0-stretch
+
+RUN apt-get update \
+    && apt install apt-transport-https build-essential curl gnupg2 lintian rpm rsync rubygems-integration ruby-dev ruby -qy \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN gem install --no-ri --no-rdoc --quiet rake fpm package_cloud
+
+WORKDIR /src
+
 RUN curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-1.12.1.tgz && tar --strip-components=1 -xvzf docker-1.12.1.tgz -C /usr/local/bin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,2 +1,0 @@
-FROM heroku/cedar:14
-COPY ./build/linux/plugn /bin/plugn

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,3 +1,2 @@
-FROM scratch
-COPY ./build/linux/plugn /plugn
-ENTRYPOINT ["/plugn"]
+FROM heroku/cedar:14
+COPY ./build/linux/plugn /bin/plugn

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,0 +1,3 @@
+FROM scratch
+COPY ./build/linux/plugn /plugn
+ENTRYPOINT ["/plugn"]

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ circleci:
 
 docker-image:
 	docker build --rm -q -f Dockerfile.hub -t $(IMAGE_NAME):$(DOCKER_VERSION) .
+	docker tag $(IMAGE_NAME):$(DOCKER_IMAGE_VERSION) $(IMAGE_NAME):hub
 
 bin/gh-release:
 	mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 
 ifeq ($(CIRCLE_BRANCH),release)
 	VERSION ?= $(BASE_VERSION)
-	DOCKER_VERSION = $(VERSION)
+	DOCKER_IMAGE_VERSION = $(VERSION)
 else
 	VERSION = $(shell echo "${BASE_VERSION}")build+$(shell git rev-parse --short HEAD)
-	DOCKER_VERSION = $(shell echo "${BASE_VERSION}")build-$(shell git rev-parse --short HEAD)
+	DOCKER_IMAGE_VERSION = $(shell echo "${BASE_VERSION}")build-$(shell git rev-parse --short HEAD)
 endif
 
 version:
@@ -121,7 +121,7 @@ circleci:
 	rm -f ~/.gitconfig
 
 docker-image:
-	docker build --rm -q -f Dockerfile.hub -t $(IMAGE_NAME):$(DOCKER_VERSION) .
+	docker build --rm -q -f Dockerfile.hub -t $(IMAGE_NAME):$(DOCKER_IMAGE_VERSION) .
 	docker tag $(IMAGE_NAME):$(DOCKER_IMAGE_VERSION) $(IMAGE_NAME):hub
 
 bin/gh-release:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = plugn
 EMAIL = plugn@josediazgonzalez.com
-MAINTAINER = josegonzalez
+MAINTAINER = dokku
 MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,127 @@
 NAME = plugn
+EMAIL = plugn@josediazgonzalez.com
+MAINTAINER = josegonzalez
+MAINTAINER_NAME = Jose Diaz-Gonzalez
+REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-VERSION ?= 0.3.1
-IMAGE_NAME ?= $(NAME)
-BUILD_TAG ?= dev
+BASE_VERSION ?= 0.3.1
+IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
+PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 
-build:
-	go-bindata bashenv
-	$(MAKE) build/darwin/$(NAME)
-	$(MAKE) build/linux/$(NAME)
-ifeq ($(CIRCLECI),true)
-	docker build -t $(IMAGE_NAME):$(BUILD_TAG) .
+ifeq ($(CIRCLE_BRANCH),release)
+	VERSION ?= $(BASE_VERSION)
+	DOCKER_VERSION = $(VERSION)
 else
-	docker build -f Dockerfile.dev -t $(IMAGE_NAME):$(BUILD_TAG) .
+	VERSION = $(shell echo "${BASE_VERSION}")build+$(shell git rev-parse --short HEAD)
+	DOCKER_VERSION = $(shell echo "${BASE_VERSION}")build-$(shell git rev-parse --short HEAD)
 endif
 
+version:
+	@echo "$(CIRCLE_BRANCH)"
+	@echo "$(VERSION)"
+
+define PACKAGE_DESCRIPTION
+Utility that allows users to register arbitrary services
+against avahi
+endef
+
+export PACKAGE_DESCRIPTION
+
+LIST = build release release-packagecloud validate
+targets = $(addsuffix -in-docker, $(LIST))
+
+.env.docker:
+	@rm -f .env.docker
+	@touch .env.docker
+	@echo "CIRCLE_BRANCH=$(CIRCLE_BRANCH)" >> .env.docker
+	@echo "GITHUB_ACCESS_TOKEN=$(GITHUB_ACCESS_TOKEN)" >> .env.docker
+	@echo "IMAGE_NAME=$(IMAGE_NAME)" >> .env.docker
+	@echo "PACKAGECLOUD_REPOSITORY=$(PACKAGECLOUD_REPOSITORY)" >> .env.docker
+	@echo "PACKAGECLOUD_TOKEN=$(PACKAGECLOUD_TOKEN)" >> .env.docker
+	@echo "VERSION=$(VERSION)" >> .env.docker
+
+build: pre-build
+	@$(MAKE) build/darwin/$(NAME)
+	@$(MAKE) build/linux/$(NAME)
+	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
+	@$(MAKE) build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
+
+build-docker-image:
+	docker build --rm -q -f Dockerfile.build -t $(IMAGE_NAME):build .
+
+$(targets): %-in-docker: .env.docker
+	docker run \
+		--env-file .env.docker \
+		--rm \
+		--volume /var/lib/docker:/var/lib/docker \
+		--volume /var/run/docker.sock:/var/run/docker.sock:ro \
+		--volume ${PWD}:/src/github.com/$(MAINTAINER)/$(REPOSITORY) \
+		--workdir /src/github.com/$(MAINTAINER)/$(REPOSITORY) \
+		$(IMAGE_NAME):build make -e $(@:-in-docker=)
 
 build/darwin/$(NAME):
 	mkdir -p build/darwin
 	CGO_ENABLED=0 GOOS=darwin go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
-										-ldflags "-X main.Version=$(VERSION)" \
+										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-o build/darwin/$(NAME)
 
 build/linux/$(NAME):
 	mkdir -p build/linux
 	CGO_ENABLED=0 GOOS=linux go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
-										-ldflags "-X main.Version=$(VERSION)" \
+										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-o build/linux/$(NAME)
 
-deps:
-	go get -u github.com/jteeuwen/go-bindata/...
-	go get -u github.com/progrium/basht/...
+build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)
+	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \
+		&& mkdir -p build/deb \
+		&& fpm \
+		--architecture amd64 \
+		--category utils \
+		--description "$$PACKAGE_DESCRIPTION" \
+		--input-type dir \
+		--license 'MIT License' \
+		--maintainer "$(MAINTAINER_NAME) <$(EMAIL)>" \
+		--name $(NAME) \
+		--output-type deb \
+		--package build/deb/$(NAME)_$(VERSION)_amd64.deb \
+		--url "https://github.com/$(MAINTAINER)/$(REPOSITORY)" \
+		--vendor "" \
+		--version $(VERSION) \
+		--verbose \
+		build/linux/$(NAME)=/usr/bin/$(NAME) \
+		LICENSE=/usr/share/doc/$(NAME)/copyright
+
+build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm: build/linux/$(NAME)
+	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \
+		&& mkdir -p build/rpm \
+		&& fpm \
+		--architecture x86_64 \
+		--category utils \
+		--description "$$PACKAGE_DESCRIPTION" \
+		--input-type dir \
+		--license 'MIT License' \
+		--maintainer "$(MAINTAINER_NAME) <$(EMAIL)>" \
+		--name $(NAME) \
+		--output-type rpm \
+		--package build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm \
+		--rpm-os linux \
+		--url "https://github.com/$(MAINTAINER)/$(REPOSITORY)" \
+		--vendor "" \
+		--version $(VERSION) \
+		--verbose \
+		build/linux/$(NAME)=/usr/bin/$(NAME) \
+		LICENSE=/usr/share/doc/$(NAME)/copyright
+
+clean:
+	rm -rf build release validation
+
+circleci:
+	docker version
+	rm -f ~/.gitconfig
+
+docker-image:
+	docker build --rm -q -f Dockerfile.hub -t $(IMAGE_NAME):$(DOCKER_VERSION) .
 
 bin/gh-release:
 	mkdir -p bin
@@ -42,28 +133,44 @@ release: build bin/gh-release
 	rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_linux_$(HARDWARE).tgz -C build/linux $(NAME)
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_$(HARDWARE).tgz -C build/darwin $(NAME)
-	bin/gh-release create dokku/$(NAME) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
+	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
+	cp build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm release/$(NAME)-$(VERSION)-1.x86_64.rpm
+	bin/gh-release create $(MAINTAINER)/$(REPOSITORY) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
 
-build-in-docker:
-	docker build --rm -f Dockerfile.build -t $(NAME)-build .
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro \
-		-v /var/lib/docker:/var/lib/docker \
-		-v ${PWD}:/src/github.com/dokku/plugn -w /src/github.com/dokku/plugn \
-		-e IMAGE_NAME=$(IMAGE_NAME) -e BUILD_TAG=$(BUILD_TAG) -e VERSION=master \
-		$(NAME)-build make -e deps build
-	docker rmi $(NAME)-build || true
+release-packagecloud:
+	@$(MAKE) release-packagecloud-deb
+	@$(MAKE) release-packagecloud-rpm
 
-test:
+release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/trusty  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/utopic  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/vivid   build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/wily    build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/xenial  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/yakkety build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/zesty   build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/artful  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/bionic  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/wheezy  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/jessie  build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/stretch build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/buster  build/deb/$(NAME)_$(VERSION)_amd64.deb
+
+release-packagecloud-rpm: build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/el/7           build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
+
+validate:
 	basht tests/*/tests.sh
+	mkdir -p validation
+	lintian build/deb/$(NAME)_$(VERSION)_amd64.deb || true
+	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_amd64.deb
+	dpkg -c build/deb/$(NAME)_$(VERSION)_amd64.deb
+	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_amd64.deb
+	cd validation && rpm2cpio ../build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm > $(NAME)-$(VERSION)-1.x86_64.cpio
+	ls -lah build/deb build/rpm validation
+	sha1sum build/deb/$(NAME)_$(VERSION)_amd64.deb
+	sha1sum build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 
-circleci:
-	docker version
-	rm -f ~/.gitconfig
-	mv Dockerfile.dev Dockerfile
-
-clean:
-	rm -rf build/*
-	docker rm $(shell docker ps -aq) || true
-	docker rmi plugn:dev || true
-
-.PHONY: build release deps build-in-docker clean test circleci
+pre-build:
+	cd / && go get -u github.com/jteeuwen/go-bindata/...
+	cd / && go get -u github.com/progrium/basht/...

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb
 release-packagecloud-rpm: build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/el/7           build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 
-validate:
+validate: pre-build
 	basht tests/*/tests.sh
 	mkdir -p validation
 	lintian build/deb/$(NAME)_$(VERSION)_amd64.deb || true

--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,7 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb
 release-packagecloud-rpm: build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/el/7           build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 
-validate: pre-build
-	basht tests/*/tests.sh
+validate: test
 	mkdir -p validation
 	lintian build/deb/$(NAME)_$(VERSION)_amd64.deb || true
 	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_amd64.deb
@@ -174,3 +173,6 @@ validate: pre-build
 pre-build:
 	cd / && go get -u github.com/jteeuwen/go-bindata/...
 	cd / && go get -u github.com/progrium/basht/...
+
+test: pre-build docker-image
+	basht tests/*/tests.sh

--- a/tests/functional/tests.sh
+++ b/tests/functional/tests.sh
@@ -2,14 +2,14 @@
 plugn-test-pass() {
 	declare name="$1" script="$2"
 	docker run $([[ "$CI" ]] || echo "--rm") -v "$PWD:/mnt" \
-		"plugn:dev" bash -c "set -e; export PLUGIN_PATH=/var/lib/plugins; $script" \
+		"dokku/plugn:hub" bash -c "set -e; export PLUGIN_PATH=/var/lib/plugins; $script" \
 		|| $T_fail "$name exited non-zero"
 }
 
 plugn-test-fail() {
 	declare name="$1" script="$2"
 	docker run $([[ "$CI" ]] || echo "--rm") -v "$PWD:/mnt" \
-		"plugn:dev" bash -c "set -e; export PLUGIN_PATH=/var/lib/plugins; $script" \
+		"dokku/plugn:hub" bash -c "set -e; export PLUGIN_PATH=/var/lib/plugins; $script" \
 		|| echo "$name exited non-zero (as expected)"
 }
 


### PR DESCRIPTION
Allow building deb and rpm packages in CI, which are pushed to packagecloud and also to the GitHub release itself.