### PR TITLE
Downgrade golang to avoid spurious SIGURG signals

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,14 +1,12 @@
-FROM golang:1.17.2-buster
+FROM golang:1.12.0-stretch
 
-# hadolint ignore=DL3027
 RUN apt-get update \
-    && apt install apt-transport-https bats build-essential curl gnupg2 lintian rpm rsync rubygems-integration ruby-dev ruby -qy \
+    && apt install apt-transport-https build-essential curl gnupg2 lintian rpm rsync rubygems-integration ruby-dev ruby -qy \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# hadolint ignore=DL3028
 RUN gem install --no-ri --no-rdoc --quiet rake fpm package_cloud
 
 WORKDIR /src
 
-RUN curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-1.12.1.tgz && tar --strip-components=1 -xvzf docker-1.12.1.tgz -C /usr/local/bin && rm docker-1.12.1.tgz
+RUN curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-1.12.1.tgz && tar --strip-components=1 -xvzf docker-1.12.1.tgz -C /usr/local/bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module plugn
 
-go 1.16
+go 1.12
 
 require (
 	github.com/BurntSushi/toml v0.4.1


### PR DESCRIPTION
This is due to an upgrade past 1.14. Rather than dig into _why_ this is occuring - which definitely has to do with not killing goroutines correctly - lets just avoid the upgrade for now.