### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.8.0](https://github.com/dokku/plugn/compare/v0.7.1...v0.8.0) - 2022-01-31
+
+### Added
+
+- @josegonzalez Update the release name and body after creation #60
+- @josegonzalez Add arm64 support #63
+- @josegonzalez Add dependabot for docker #64
+
+### Fixed
+
+- @josegonzalez Add jq to build environment #67
+
+### Changed
+
+- @josegonzalez Upgrade ci builder to ubuntu 20.04 #61
+- @josegonzalez Update dockerfile to newer base image #66
+- @dependabot chore(deps): bump github.com/BurntSushi/toml from 0.4.1 to 1.0.0 #62
+- @dependabot chore(deps): bump golang from 1.12.0-stretch to 1.17.6-stretch #65
+
 ## [0.7.1](https://github.com/dokku/plugn/compare/v0.7.0...v0.7.1) - 2021-10-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.8.1](https://github.com/dokku/plugn/compare/v0.8.0...v0.8.1) - 2022-03-05
+
+### Added
+
+- @RyanGaudion Add Raspbian Bullseye #70
+
+### Changed
+
+- @dependabot chore(deps): bump golang from 1.17.6-buster to 1.17.7-buster #69
+
 ## [0.8.0](https://github.com/dokku/plugn/compare/v0.7.1...v0.8.0) - 2022-01-31
 
 ### Added

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-stretch
+FROM golang:1.17.6-buster
 
 # hadolint ignore=DL3027
 RUN apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.8.0
+BASE_VERSION ?= 0.8.1
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.7.1
+BASE_VERSION ?= 0.8.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hook system that lets users extend your application with plugins
 
 ## Installation
 ```
-$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.0/plugn_0.8.0_linux_amd64.tgz
+$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.1/plugn_0.8.1_linux_amd64.tgz
 $ tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hook system that lets users extend your application with plugins
 
 ## Installation
 ```
-$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.7.1/plugn_0.7.1_linux_amd64.tgz
+$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.0/plugn_0.8.0_linux_amd64.tgz
 $ tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 


### PR DESCRIPTION
### Added

- @RyanGaudion Add Raspbian Bullseye #70

### Changed

- @dependabot chore(deps): bump golang from 1.17.6-buster to 1.17.7-buster #69
