### PR TITLE
Switch to golang 1.13 to fix SIGURG issue

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.17.7-buster
+FROM golang:1.13.0-buster
 
 # hadolint ignore=DL3027
 RUN apt-get update \


### PR DESCRIPTION
This fixes an issue with SIGURG introduced in https://github.com/golang/go/issues/37942