### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.8.0](https://github.com/dokku/plugn/compare/v0.7.1...v0.8.0) - 2022-01-31
+
+### Added
+
+- @josegonzalez Update the release name and body after creation #60
+- @josegonzalez Add arm64 support #63
+- @josegonzalez Add dependabot for docker #64
+
+### Fixed
+
+- @josegonzalez Add jq to build environment #67
+
+### Changed
+
+- @josegonzalez Upgrade ci builder to ubuntu 20.04 #61
+- @josegonzalez Update dockerfile to newer base image #66
+- @dependabot chore(deps): bump github.com/BurntSushi/toml from 0.4.1 to 1.0.0 #62
+- @dependabot chore(deps): bump golang from 1.12.0-stretch to 1.17.6-stretch #65
+
 ## [0.7.1](https://github.com/dokku/plugn/compare/v0.7.0...v0.7.1) - 2021-10-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.9.0](https://github.com/dokku/plugn/compare/v0.8.2...v0.9.0) - 2022-05-10
+
+### Changed
+
+- #79 @dependabot chore(deps): bump github.com/BurntSushi/toml from 1.0.0 to 1.1.0
+- #80 @dependabot  chore(deps): bump golang from 1.13.0-buster to 1.18.1-buster
+
+### Added
+
+- #77 @josegonzalez Publish armhf package to ubuntu/focal
+- #81 @josegonzalez Publish package for Ubuntu 22.04
+
 ## [0.8.2](https://github.com/dokku/plugn/compare/v0.8.1...v0.8.2) - 2022-03-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.8.2](https://github.com/dokku/plugn/compare/v0.8.1...v0.8.2) - 2022-03-05
+
+### Changed
+
+- @RyanGaudion Switch to golang 1.13 to fix SIGURG issue #74
+
 ## [0.8.1](https://github.com/dokku/plugn/compare/v0.8.0...v0.8.1) - 2022-03-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.8.1](https://github.com/dokku/plugn/compare/v0.8.0...v0.8.1) - 2022-03-05
+
+### Added
+
+- @RyanGaudion Add Raspbian Bullseye #70
+
+### Changed
+
+- @dependabot chore(deps): bump golang from 1.17.6-buster to 1.17.7-buster #69
+
 ## [0.8.0](https://github.com/dokku/plugn/compare/v0.7.1...v0.8.0) - 2022-01-31
 
 ### Added

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-buster
+FROM golang:1.17.7-buster
 
 # hadolint ignore=DL3027
 RUN apt-get update \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.13.0-buster
+FROM golang:1.18.1-buster
 
 # hadolint ignore=DL3027
 RUN apt-get update \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-stretch
+FROM golang:1.17.6-buster
 
 # hadolint ignore=DL3027
 RUN apt-get update \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.17.7-buster
+FROM golang:1.13.0-buster
 
 # hadolint ignore=DL3027
 RUN apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -211,11 +211,14 @@ release-packagecloud:
 release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAME)_$(VERSION)_arm64.deb build/deb/$(NAME)_$(VERSION)_armhf.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/bionic  build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal   build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy   build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/stretch build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/buster  build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_arm64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy    build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_armhf.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy    build/deb/$(NAME)_$(VERSION)_armhf.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/buster build/deb/$(NAME)_$(VERSION)_armhf.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_armhf.deb
 

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAM
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/buster  build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_arm64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_armhf.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/buster build/deb/$(NAME)_$(VERSION)_armhf.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_armhf.deb
 

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,7 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAM
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/buster build/deb/$(NAME)_$(VERSION)_armhf.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_armhf.deb
 
 release-packagecloud-rpm: build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/el/7           build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.8.1
+BASE_VERSION ?= 0.8.2
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.8.2
+BASE_VERSION ?= 0.9.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,8 @@ validate: test
 	sha1sum build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 
 prebuild:
-	cd / && go get -u github.com/jteeuwen/go-bindata/...
-	cd / && go get -u github.com/progrium/basht/...
+	cd / && go install github.com/jteeuwen/go-bindata/...@latest
+	cd / && go install github.com/progrium/basht/...@latest
 
 test: prebuild docker-image
 	basht tests/*/tests.sh

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.8.0
+BASE_VERSION ?= 0.8.1
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.7.1
+BASE_VERSION ?= 0.8.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hook system that lets users extend your application with plugins
 
 ## Installation
 ```
-$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.0/plugn_0.8.0_linux_amd64.tgz
+$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.1/plugn_0.8.1_linux_amd64.tgz
 $ tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hook system that lets users extend your application with plugins
 
 ## Installation
 ```
-$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.7.1/plugn_0.7.1_linux_amd64.tgz
+$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.0/plugn_0.8.0_linux_amd64.tgz
 $ tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 Hook system that lets users extend your application with plugins
 
 ## Installation
-```
-$ wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.1/plugn_0.8.1_linux_amd64.tgz
-$ tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
+
+```shell
+wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.2/plugn_0.8.2_linux_amd64.tgz
+tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hook system that lets users extend your application with plugins
 ## Installation
 
 ```shell
-wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.2/plugn_0.8.2_linux_amd64.tgz
+wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.9.0/plugn_0.9.0_linux_amd64.tgz
 tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module plugn
 go 1.12
 
 require (
-	github.com/BurntSushi/toml v1.0.0
+	github.com/BurntSushi/toml v1.1.0
 	github.com/dokku/duplex v0.0.0-20160916172127-5bc6cb8042f7
 	github.com/google/uuid v1.1.4 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
-github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/dokku/duplex v0.0.0-20160916172127-5bc6cb8042f7 h1:BBMM8QczgTcNTM6axgZA2pdR5SG0eePSh2GeOLpkgRw=
 github.com/dokku/duplex v0.0.0-20160916172127-5bc6cb8042f7/go.mod h1:FagtW/LftfcKQuBjdmKHdhxCbTU7Gdv87BIOQ6dgAk4=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
### Changed

- #79 @dependabot chore(deps): bump github.com/BurntSushi/toml from 1.0.0 to 1.1.0
- #80 @dependabot  chore(deps): bump golang from 1.13.0-buster to 1.18.1-buster

### Added

- #77 @josegonzalez Publish armhf package to ubuntu/focal
- #81 @josegonzalez Publish package for Ubuntu 22.04