### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.9.1](https://github.com/dokku/plugn/compare/v0.9.0...v0.9.1) - 2022-05-10
+
+### Changed
+
+- @josegonzalez Revert "chore(deps): bump golang from 1.13.0-buster to 1.18.1-buster" #83
+
 ## [0.9.0](https://github.com/dokku/plugn/compare/v0.8.2...v0.9.0) - 2022-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.9.0](https://github.com/dokku/plugn/compare/v0.8.2...v0.9.0) - 2022-05-10
+
+### Changed
+
+- #79 @dependabot chore(deps): bump github.com/BurntSushi/toml from 1.0.0 to 1.1.0
+- #80 @dependabot  chore(deps): bump golang from 1.13.0-buster to 1.18.1-buster
+
+### Added
+
+- #77 @josegonzalez Publish armhf package to ubuntu/focal
+- #81 @josegonzalez Publish package for Ubuntu 22.04
+
 ## [0.8.2](https://github.com/dokku/plugn/compare/v0.8.1...v0.8.2) - 2022-03-05
 
 ### Changed

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.18.1-buster
+FROM golang:1.13.0-buster
 
 # hadolint ignore=DL3027
 RUN apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,8 @@ validate: test
 	sha1sum build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 
 prebuild:
-	cd / && go install github.com/jteeuwen/go-bindata/...@latest
-	cd / && go install github.com/progrium/basht/...@latest
+	cd / && go get -u github.com/jteeuwen/go-bindata/...
+	cd / && go get -u github.com/progrium/basht/...
 
 test: prebuild docker-image
 	basht tests/*/tests.sh

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.9.0
+BASE_VERSION ?= 0.9.1
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = plugn
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.8.2
+BASE_VERSION ?= 0.9.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hook system that lets users extend your application with plugins
 ## Installation
 
 ```shell
-wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.9.0/plugn_0.9.0_linux_amd64.tgz
+wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.9.1/plugn_0.9.1_linux_amd64.tgz
 tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hook system that lets users extend your application with plugins
 ## Installation
 
 ```shell
-wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.8.2/plugn_0.8.2_linux_amd64.tgz
+wget -qO /tmp/plugn_latest.tgz https://github.com/dokku/plugn/releases/download/v0.9.0/plugn_0.9.0_linux_amd64.tgz
 tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 


### PR DESCRIPTION
### Changed

- @josegonzalez Revert "chore(deps): bump golang from 1.13.0-buster to 1.18.1-buster" #83
