### PR TITLE
Remove usage of deprecated package io/ioutil

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -42,7 +41,7 @@ func runGateway() {
 
 func findPlugins() []string {
 	var plugins []string
-	enabled, err := ioutil.ReadDir(PluginPath + "/enabled")
+	enabled, err := os.ReadDir(PluginPath + "/enabled")
 	if err != nil {
 		log.Println(err)
 		return []string{}

--- a/plugn.go
+++ b/plugn.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -22,7 +22,7 @@ func assert(err error) {
 }
 
 func TomlGet(args []string) {
-	bytes, err := ioutil.ReadAll(os.Stdin)
+	bytes, err := io.ReadAll(os.Stdin)
 	assert(err)
 	var t map[string]interface{}
 	_, err = toml.Decode(string(bytes), &t)
@@ -32,7 +32,7 @@ func TomlGet(args []string) {
 
 func TomlExport(args []string) {
 	plugin := args[0]
-	bytes, err := ioutil.ReadAll(os.Stdin)
+	bytes, err := io.ReadAll(os.Stdin)
 	assert(err)
 
 	var c map[string]map[string]string
@@ -53,7 +53,7 @@ func TomlExport(args []string) {
 }
 
 func TomlSet(args []string) {
-	bytes, err := ioutil.ReadAll(os.Stdin)
+	bytes, err := io.ReadAll(os.Stdin)
 	assert(err)
 	var t map[string]map[string]string
 	_, err = toml.DecodeFile(args[0], &t)
@@ -74,7 +74,7 @@ func isArg(argument string) bool {
 
 func main() {
 	os.Setenv("PLUGN_VERSION", Version)
-	if data, err := ioutil.ReadFile(".plugn"); err == nil {
+	if data, err := os.ReadFile(".plugn"); err == nil {
 		if path, err := filepath.Abs(string(data)); err == nil {
 			os.Setenv("PLUGIN_PATH", path)
 		}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by io or os