### PR TITLE
feat: change the integration branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
-      - 'release'
+      - "main"
 
 jobs:
   build:
@@ -21,24 +20,24 @@ jobs:
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v4
-    - name: make version
-      run: |
-        make version .env.docker
-    - run: make ci-report
-    - run: make build-docker-image
-    - run: make build-in-docker
-    - run: make validate-in-docker
-    - name: upload packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: build
-        path: build/**/*
-    - name: make release-in-docker
-      run: |
-        if [[ "${GITHUB_REF#refs/heads/}" == "release" ]]; then
-          export CI_BRANCH=${GITHUB_REF#refs/heads/}
-          export PACKAGECLOUD_REPOSITORY=dokku/dokku
-          rm .env.docker
-          make .env.docker release-in-docker release-packagecloud-in-docker
-        fi
+      - uses: actions/checkout@v4
+      - name: make version
+        run: |
+          make version .env.docker
+      - run: make ci-report
+      - run: make build-docker-image
+      - run: make build-in-docker
+      - run: make validate-in-docker
+      - name: upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build/**/*
+      - name: make release-in-docker
+        run: |
+          if [[ "${GITHUB_REF#refs/heads/}" == "release" ]]; then
+            export CI_BRANCH=${GITHUB_REF#refs/heads/}
+            export PACKAGECLOUD_REPOSITORY=dokku/dokku
+            rm .env.docker
+            make .env.docker release-in-docker release-packagecloud-in-docker
+          fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - "main"
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches:
+      - "main"
   schedule:
-    - cron: '21 18 * * 3'
+    - cron: "21 18 * * 3"
 
 jobs:
   analyze:
@@ -32,40 +34,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# plugn [![Build Status](https://img.shields.io/circleci/project/dokku/plugn/master.svg?style=flat-square "Build Status")](https://circleci.com/gh/dokku/plugn/tree/master)
+# plugn
 
 Hook system that lets users extend your application with plugins
 
@@ -10,6 +10,7 @@ tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 ```
 
 ## Usage
+
 ```
 $ PLUGIN_PATH=/var/lib/dokku/plugins plugn
 
@@ -29,14 +30,16 @@ Available commands:
 ```
 
 ## Building & Testing (in docker)
+
 ```
-$ docker-machine create -d virtualbox plugn-dev
-$ eval $(docker-machine env plugn-dev)
-$ make build-in-docker
-$ make test
+docker-machine create -d virtualbox plugn-dev
+eval $(docker-machine env plugn-dev)
+make build-in-docker
+make test
 ```
 
 ## Plugin directory structure example
+
 ```
 ps (plugin name)
 ├── [-rw-r--r--]  plugin.toml (metadata)
@@ -46,6 +49,7 @@ ps (plugin name)
 ```
 
 ## plugin.toml format example
+
 ```
 [plugin name]
 description = "plugin description"
@@ -54,7 +58,7 @@ version = "0.1.0"
 
 ## Releases
 
-Anybody can propose a release. First bump the version in `Makefile`, make sure `CHANGELOG.md` is up to date, and make sure tests are passing. Then open a Pull Request from `master` into the `release` branch. Once a maintainer approves and merges, CircleCI will build a release and upload it to Github.
+Anybody can propose a release. First bump the version in `Makefile`, make sure `CHANGELOG.md` is up to date, and make sure tests are passing. Then open a Pull Request from `main` into the `release` branch. Once a maintainer approves and merges, CircleCI will build a release and upload it to Github.
 
 ## License
 


### PR DESCRIPTION
Most of my tooling uses main, so this makes autocompletion on the cli easier for me as I perform repo maintenance.