### PR TITLE
Fix the plugn shell dev helper on linux

### DIFF
--- a/plugn
+++ b/plugn
@@ -1,2 +1,24 @@
 #!/bin/bash
-exec "$(dirname $BASH_SOURCE)/build/$(uname | awk '{print tolower($0)}')/plugn" "$@" 
+set -eu
+os_name=$(uname)
+os_name=${os_name,,}
+
+bin_suffix=""
+
+if [[ "$os_name" == "linux" ]]; then
+	# TODO: Apple M2?
+	os_arch="$(uname -m)"
+	case "$os_arch" in
+	x86_64)
+		bin_suffix="-amd64"
+		;;
+	arm64 | aarch64)
+		bin_suffix="-arm64"
+		;;
+	*)
+		echo "Unsupported CPU architecture: $os_arch" >&2 && exit 1
+		;;
+	esac
+fi
+
+exec "$(dirname "${BASH_SOURCE[0]}")/build/${os_name}/plugn${bin_suffix}" "$@"


### PR DESCRIPTION
This automatically selects a file suffix on linux based on `uname -m`. I've also made lowercasing the output of `uname` to use the bashism `${X,,}`.

There's room for Apple M2 if separate binaries ever need to be built for that.