### PR TITLE
Fix tgz download failures not treated as errors

### DIFF
--- a/tests/functional/tests.sh
+++ b/tests/functional/tests.sh
@@ -59,6 +59,12 @@ T_plugn-install-enable-disable-targz() {
 		plugn list | grep disabled | grep smoke-test-plugin"
 }
 
+T_plugn-install-enable-disable-targz-404() {
+	plugn-test-fail "test-install-targz-404" "
+		plugn init && \
+		plugn install https://github.com/dokku/smoke-test-plugin/archive/notfound.tar.gz smoke-test-plugin"
+}
+
 T_plugn-install-twice() {
   url="https://github.com/dokku/smoke-test-plugin"
   plugn-test-pass "test-install-twice" "


### PR DESCRIPTION
Fixes #23

Bug is caused by `curl ... | tar xz` being followed by `&&`. This suppresses any errors, even with `set -eo pipefail`. 

Also curl was missing the `-f` flag to treat non-2xx status codes as errors. wget already treats non-2xx as errors.
