### PR TITLE
tests: Move `safe.directory` git config to dockerfile

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,6 +6,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN git config --global --add safe.directory '*'
+
 # hadolint ignore=DL3028
 RUN gem install --quiet rake fpm package_cloud
 

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,6 @@ validate: test
 	sha1sum build/deb/$(NAME)_$(VERSION)_arm64.deb
 
 prebuild:
-	git config --global --add safe.directory $(shell pwd)
 	git status
 	cd / && go install github.com/progrium/basht/...@latest
 


### PR DESCRIPTION
This prevents duplicate git config values of `safe.directory` when make is not run in docker.

Fixes #156 