### PR TITLE
chore: update go-basher to v5.1.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module plugn
 
-go 1.23.0
-
+go 1.22
 toolchain go1.24.1
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module plugn
 
-go 1.22
+go 1.23.0
+
 toolchain go1.24.1
 
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/dokku/duplex v0.0.0-20160916172127-5bc6cb8042f7
-	github.com/progrium/go-basher v5.1.7+incompatible
+	github.com/progrium/go-basher v5.1.8+incompatible
 	github.com/progrium/plugin-demo v0.0.0-20160206152045-d94df2206a64
 )
 

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/progrium/crypto v0.0.0-20141231035031-e04455474e32 h1:TazRiCelU8NoJMn
 github.com/progrium/crypto v0.0.0-20141231035031-e04455474e32/go.mod h1:spjB7wUvxDfIjoK9jtlCu07B/QaZwjtKlQeM3njS9QA=
 github.com/progrium/go-basher v5.1.7+incompatible h1:0ezYhhUW4Ie0h5faBKZWq+Ajn9VyR7mGI3ayi7khS7c=
 github.com/progrium/go-basher v5.1.7+incompatible/go.mod h1:Oiy7jZEU1mm+gI1dt5MKYwxptmD37q8/UupxnwhMHtI=
+github.com/progrium/go-basher v5.1.8+incompatible h1:2GQffE0yLIreCPzEvNqn8ftnSQBvR9p31hgfZeuveVQ=
+github.com/progrium/go-basher v5.1.8+incompatible/go.mod h1:Oiy7jZEU1mm+gI1dt5MKYwxptmD37q8/UupxnwhMHtI=
 github.com/progrium/plugin-demo v0.0.0-20160206152045-d94df2206a64 h1:FHNCTel7Yt0+4I1uvKfu2X+g8U8tHBBJb7zl+ohfmqM=
 github.com/progrium/plugin-demo v0.0.0-20160206152045-d94df2206a64/go.mod h1:xwVfSlPMRhFysvnn0lOZ1Ruen2jTuzgwm4Hs0onTrlY=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=


### PR DESCRIPTION
This bumps go-basher to v5.1.8, which includes a fix I contributed (progrium/go-basher#53) for a bug where I think Bash 5.x silently skips sourcing `BASH_ENV` when stdin is a Unix socket. This causes `main: command not found` (exit 127) errors in plugn commands when the calling process has a socket as stdin — which I believe comes up with process supervisors, systemd socket activation, etc.

I think this is the same root cause as dokku/dokku#5764.

The fix explicitly sources the envfile in the `-c` command string instead of relying solely on `BASH_ENV`, which should resolve the issue.

## Test plan
- [ ] Verify plugn builds successfully with the updated dependency