### PR TITLE
fix: plug fd leak in TomlSet and clean failed install dirs

### DIFF
--- a/bashenv/plugn.bash
+++ b/bashenv/plugn.bash
@@ -26,6 +26,7 @@ install() {
 			exit 1
 		fi
 		mkdir -p "$name"
+		trap 'rm -rf "$PLUGIN_PATH/available/$name"' ERR INT TERM
     command "${downloader[@]}" "$url" | tar xz -C "$name"
     pushd "$name" &>/dev/null
 		# make sure we untarred a single dir into our target
@@ -38,6 +39,7 @@ install() {
 			popd &>/dev/null
 			rmdir "$cwd"
 		fi
+		trap - ERR INT TERM
 	elif [[ -d "$name" ]]; then
     # plugin is already installed
     if [[ ! -d "$name/.git" ]]; then

--- a/plugn.go
+++ b/plugn.go
@@ -74,8 +74,9 @@ func TomlSet(args []string) {
 	t[args[1]][args[2]] = string(bytes)
 	f, err := os.Create(args[0])
 	assert(err)
+	defer f.Close()
 	assert(toml.NewEncoder(f).Encode(t))
-	f.Close()
+	assert(f.Sync())
 }
 
 func isArg(argument string) bool {


### PR DESCRIPTION
The encoder error in `TomlSet` triggered `log.Fatal` before the explicit `f.Close()` ran, leaking the file descriptor and any unflushed writes. The bash `install` command also left a partially extracted directory under `$PLUGIN_PATH/available/` when `curl | tar xz` failed, which then blocked any retry through the "already installed" branch.