### PR TITLE
chore(deps): bump json from 2.15.2.1 to 2.21.2 in /.github

### DIFF
--- a/.github/Gemfile.lock
+++ b/.github/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     http-cookie (1.1.0)
       domain_name (~> 0.5)
     insist (1.0.0)
-    json (2.15.2.1)
+    json (2.21.2)
     logger (1.7.0)
     mime-types (3.7.0)
       logger


### PR DESCRIPTION
Resolves Dependabot security alert #21 by bumping the `json` RubyGem from `2.15.2.1` to `2.21.2` in `.github/Gemfile.lock`, moving it out of the vulnerable range `>= 2.9.0, < 2.19.9` reported by GHSA-x2f5-4prf-w687 / CVE-2026-54696.

The advisory describes a heap out-of-bounds write (CWE-122) on the JSON generator's IO-streaming path, where `JSON.dump(obj, io)` and `JSON::State#generate(obj, io)` can write past the internal buffer when a streamed object contains an attacker-controlled string near the 16 KB boundary, resulting in a reliable denial of service. The demonstrated impact is a process crash and the fix first landed in json `2.19.9`.

`json` is a transitive dependency pulled in by `package_cloud` under the constraint `json (~> 2.9)`, which `2.19.9` continues to satisfy, so no other lockfile entries change. This Gemfile is release tooling used only by the `tagged-release` workflow to build Debian packages with `fpm` and publish them to PackageCloud, and no application code invokes the affected IO-streaming path, so this is a dependency bump with no behavioral change.
